### PR TITLE
Refactor: Remove opacity changes from background animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,15 +12,15 @@
         }
 
         @keyframes slowDriftLeftToRight {
-            0% { transform: translateX(0px); opacity: 0.05; } /* Lower min opacity */
-            50% { transform: translateX(15px); opacity: 0.2; } /* Reduced movement, adjusted max opacity */
-            100% { transform: translateX(0px); opacity: 0.05; }
+            0% { transform: translateX(0px); } /* Lower min opacity */
+            50% { transform: translateX(15px); } /* Reduced movement, adjusted max opacity */
+            100% { transform: translateX(0px); }
         }
         
         @keyframes slowDriftRightToLeft {
-            0% { transform: translateX(0px); opacity: 0.2; } /* Adjusted max opacity */
-            50% { transform: translateX(-15px); opacity: 0.05; } /* Reduced movement, lower min opacity */
-            100% { transform: translateX(0px); opacity: 0.2; }
+            0% { transform: translateX(0px); } /* Adjusted max opacity */
+            50% { transform: translateX(-15px); } /* Reduced movement, lower min opacity */
+            100% { transform: translateX(0px); }
         }
 
         body {


### PR DESCRIPTION
The background human and robot SVG elements will now move continuously without fading in and out. This is achieved by removing the opacity transitions from the `slowDriftLeftToRight` and `slowDriftRightToLeft` CSS keyframes. The elements will maintain their base opacity throughout the animation, providing constant visibility.